### PR TITLE
Add cloud deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ No debugging nightmares. No messy dependencies. Just results
 🔥 Ready to level up your AI projects? Install OneLinerML now:
 pip install OneLinerML
 
+## Deployment
+
+Run locally with localtunnel:
+
+```bash
+onelinerml-serve data.csv --target price --model random_forest --deploy-mode local
+```
+
+Cloud deployment using a config file:
+
+```bash
+onelinerml-serve data.csv --target price --deploy-mode cloud --config-path examples/cloud_config.yaml
+```
+
 # For Data Scientists
 
 🚀 Focus on Insights, Not Implementation

--- a/examples/cloud_config.yaml
+++ b/examples/cloud_config.yaml
@@ -1,0 +1,5 @@
+provider: aws
+region: us-east-1
+api_port: 8000
+dashboard_port: 8503
+ngrok_auth_token: YOUR_NGROK_TOKEN

--- a/onelinerml/api.py
+++ b/onelinerml/api.py
@@ -33,7 +33,9 @@ async def root():
 async def train_endpoint(
     file: UploadFile = File(...),
     model: str = "linear_regression",
-    target_column: str = "target"
+    target_column: str = "target",
+    deploy_mode: str = "local",
+    config_path: str | None = None
 ):
     global model_global
     try:
@@ -45,20 +47,30 @@ async def train_endpoint(
         df,
         model=model,
         target_column=target_column,
-        model_save_path=MODEL_PATH
+        model_save_path=MODEL_PATH,
+        deploy_mode=deploy_mode,
+        config_path=config_path
     )
     model_global = trained_model
     return {"metrics": metrics}
 
 @app.post("/deploy")
-async def deploy_endpoint(file: UploadFile = File(...)):
+async def deploy_endpoint(
+    file: UploadFile = File(...),
+    deploy_mode: str = "local",
+    config_path: str | None = None
+):
     """
     Upload a pre-trained model (joblib or pickle) and deploy it.
     """
     contents = await file.read()
     with open(MODEL_PATH, "wb") as f:
         f.write(contents)
-    api_url, dash_url = deploy_model_from_path(MODEL_PATH)
+    api_url, dash_url = deploy_model_from_path(
+        MODEL_PATH,
+        deploy_mode=deploy_mode,
+        config_path=config_path
+    )
     return {"api_url": api_url, "dashboard_url": dash_url}
 
 @app.post("/predict")

--- a/onelinerml/cloud.py
+++ b/onelinerml/cloud.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import time
+import json
+from pyngrok import ngrok
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+
+def _load_config(config_path):
+    with open(config_path, "r") as f:
+        if config_path.endswith((".yml", ".yaml")):
+            if yaml is None:
+                raise ImportError("PyYAML is required for YAML config files")
+            return yaml.safe_load(f)
+        return json.load(f)
+
+
+def deploy_api_and_dashboard_cloud(config_path):
+    """Deploy the API and dashboard using a cloud tunnel (ngrok)."""
+    if not config_path or not os.path.exists(config_path):
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    config = _load_config(config_path)
+    api_port = config.get("api_port", 8000)
+    dashboard_port = config.get("dashboard_port", 8503)
+    region = config.get("region")
+    auth_token = config.get("ngrok_auth_token")
+
+    if auth_token:
+        ngrok.set_auth_token(auth_token)
+    if region:
+        ngrok.set_default_region(region)
+
+    subprocess.Popen([
+        "python3", "-m", "uvicorn", "onelinerml.api:app",
+        "--host", "0.0.0.0", "--port", str(api_port)
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    time.sleep(5)
+
+    subprocess.Popen([
+        "streamlit", "run", "onelinerml/dashboard.py",
+        "--server.port", str(dashboard_port),
+        "--server.enableCORS=false",
+        "--server.enableWebsocketCompression=false"
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(5)
+
+    api_tunnel = ngrok.connect(api_port)
+    dash_tunnel = ngrok.connect(dashboard_port)
+
+    api_url = api_tunnel.public_url
+    dash_url = dash_tunnel.public_url
+
+    print("API is accessible at:", api_url)
+    print("Dashboard is accessible at:", dash_url)
+
+    return api_url, dash_url

--- a/onelinerml/setup.py
+++ b/onelinerml/setup.py
@@ -16,7 +16,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "onelinerml-serve=onelinerml.train:train"
+            "onelinerml-serve=onelinerml.train:main"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "onelinerml-serve=onelinerml.train:train"
+            "onelinerml-serve=onelinerml.train:main"
         ]
     },
 )


### PR DESCRIPTION
## Summary
- support cloud deployment via ngrok
- add cloud deployment function and CLI entry point
- allow API endpoints to specify deployment mode
- provide cloud config example
- document local vs cloud usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dec28209c832abbe6065592c558f3