### PR TITLE
Persist preprocessor for inference

### DIFF
--- a/onelinerml/preprocessing.py
+++ b/onelinerml/preprocessing.py
@@ -29,4 +29,5 @@ def preprocess_data(data, target_column):
     ])
     
     X_preprocessed = preprocessor.fit_transform(X)
-    return X_preprocessed, y.values
+    # Return the fitted preprocessor so it can be reused for inference
+    return preprocessor, X_preprocessed, y.values


### PR DESCRIPTION
## Summary
- return fitted preprocessor from `preprocess_data`
- save preprocessor in `train` alongside the model
- load preprocessor when deploying a saved model
- update API to load the preprocessor and apply it during prediction

## Testing
- `python -m py_compile onelinerml/*.py`
- `pytest -q`
- `pip install -e .` *(fails: build dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ffae19d44832a8369c44a3636695f