### PR TITLE
Add preprocessor persistence

### DIFF
--- a/onelinerml/api.py
+++ b/onelinerml/api.py
@@ -10,17 +10,25 @@ import joblib, pickle, os
 app = FastAPI()
 
 MODEL_PATH = "trained_model.joblib"
+PREPROCESSOR_PATH = "preprocessor.joblib"
 model_global = None
+preprocessor_global = None
 
 @app.on_event("startup")
 def load_model_on_startup():
-    global model_global
+    global model_global, preprocessor_global
     if os.path.exists(MODEL_PATH):
         try:
             model_global = joblib.load(MODEL_PATH)
         except Exception:
             with open(MODEL_PATH, "rb") as f:
                 model_global = pickle.load(f)
+    if os.path.exists(PREPROCESSOR_PATH):
+        try:
+            preprocessor_global = joblib.load(PREPROCESSOR_PATH)
+        except Exception:
+            with open(PREPROCESSOR_PATH, "rb") as f:
+                preprocessor_global = pickle.load(f)
 
 class PredictRequest(BaseModel):
     data: list
@@ -37,7 +45,7 @@ async def train_endpoint(
     deploy_mode: str = "local",
     config_path: str | None = None
 ):
-    global model_global
+    global model_global, preprocessor_global
     try:
         contents = await file.read()
         df = pd.read_csv(StringIO(contents.decode("utf-8")))
@@ -48,11 +56,18 @@ async def train_endpoint(
         model=model,
         target_column=target_column,
         model_save_path=MODEL_PATH,
+        preprocessor_save_path=PREPROCESSOR_PATH,
         deploy_mode=deploy_mode,
         config_path=config_path,
         deploy=False
     )
     model_global = trained_model
+    if os.path.exists(PREPROCESSOR_PATH):
+        try:
+            preprocessor_global = joblib.load(PREPROCESSOR_PATH)
+        except Exception:
+            with open(PREPROCESSOR_PATH, "rb") as f:
+                preprocessor_global = pickle.load(f)
     return {"metrics": metrics}
 
 @app.post("/deploy")
@@ -69,6 +84,7 @@ async def deploy_endpoint(
         f.write(contents)
     api_url, dash_url = deploy_model_from_path(
         MODEL_PATH,
+        preprocessor_save_path=PREPROCESSOR_PATH,
         deploy_mode=deploy_mode,
         config_path=config_path
     )
@@ -76,13 +92,16 @@ async def deploy_endpoint(
 
 @app.post("/predict")
 async def predict_endpoint(req: PredictRequest):
-    global model_global
+    global model_global, preprocessor_global
     if model_global is None:
         raise HTTPException(status_code=400, detail="Model not available.")
     data = req.data
     if isinstance(data, list) and (not data or not isinstance(data[0], list)):
         data = [data]
     try:
+        if preprocessor_global is not None:
+            df = pd.DataFrame(data)
+            data = preprocessor_global.transform(df)
         preds = model_global.predict(data)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Prediction error: {e}")

--- a/onelinerml/dashboard.py
+++ b/onelinerml/dashboard.py
@@ -11,6 +11,11 @@ target_column = st.text_input("Target Column", "target")
 
 if data_file is not None and st.button("Train Model"):
     data = pd.read_csv(data_file)
-    model_instance, metrics = train(data, model=model_choice, target_column=target_column)
+    model_instance, metrics = train(
+        data,
+        model=model_choice,
+        target_column=target_column,
+        preprocessor_save_path="preprocessor.joblib"
+    )
     st.write("Evaluation Metrics:")
     st.json(metrics)

--- a/onelinerml/preprocessing.py
+++ b/onelinerml/preprocessing.py
@@ -29,4 +29,4 @@ def preprocess_data(data, target_column):
     ])
     
     X_preprocessed = preprocessor.fit_transform(X)
-    return X_preprocessed, y.values
+    return X_preprocessed, y.values, preprocessor


### PR DESCRIPTION
## Summary
- keep README install instructions and requirements from main
- persist preprocessing pipeline to `preprocessor.joblib`
- load preprocessor in API and apply during prediction
- support custom preprocessor path in training and deployment utilities

## Testing
- `python -m py_compile onelinerml/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffc82db9c832a8e8e0321985ad080