### PR TITLE
Fix auto-sklearn dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ joblib
 numpy
 xgboost
 lightgbm
-autosklearn
+auto-sklearn
 pydantic
 pyyaml


### PR DESCRIPTION
## Summary
- correct the dependency name from `autosklearn` to `auto-sklearn`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850016ce40c832aa7cc890417b1d565