### PR TITLE
Ensure preprocessing fits on train split

### DIFF
--- a/onelinerml/preprocessing.py
+++ b/onelinerml/preprocessing.py
@@ -5,14 +5,21 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
 
-def preprocess_data(data, target_column):
-    # Separate target variable from features
-    y = data[target_column]
-    X = data.drop(columns=[target_column])
+def preprocess_data(train_data, target_column, test_data=None):
+    """Preprocess the dataset.
+
+    If ``test_data`` is provided, the preprocessor is fitted using only
+    ``train_data`` and then applied to both train and test splits.
+    When ``test_data`` is ``None`` the entire ``train_data`` is used for both
+    fitting and transformation (backwards compatibility).
+    """
+    # Separate target variable from features in the training set
+    y_train = train_data[target_column]
+    X_train = train_data.drop(columns=[target_column])
     
     # Identify numeric and categorical columns
-    numeric_cols = X.select_dtypes(include=["int64", "float64"]).columns
-    categorical_cols = X.select_dtypes(include=["object", "category"]).columns
+    numeric_cols = X_train.select_dtypes(include=["int64", "float64"]).columns
+    categorical_cols = X_train.select_dtypes(include=["object", "category"]).columns
     
     # Build pipelines for numeric and categorical data
     numeric_pipeline = Pipeline(steps=[
@@ -28,5 +35,18 @@ def preprocess_data(data, target_column):
         ("cat", categorical_pipeline, categorical_cols)
     ])
     
-    X_preprocessed = preprocessor.fit_transform(X)
-    return X_preprocessed, y.values, preprocessor
+    X_train_preprocessed = preprocessor.fit_transform(X_train)
+
+    if test_data is not None:
+        y_test = test_data[target_column]
+        X_test = test_data.drop(columns=[target_column])
+        X_test_preprocessed = preprocessor.transform(X_test)
+        return (
+            X_train_preprocessed,
+            y_train.values,
+            X_test_preprocessed,
+            y_test.values,
+            preprocessor,
+        )
+
+    return X_train_preprocessed, y_train.values, preprocessor

--- a/onelinerml/train.py
+++ b/onelinerml/train.py
@@ -134,8 +134,8 @@ def train(
     """
     Full training pipeline:
       - Load CSV or DataFrame
-      - Preprocess
       - Train/test split
+      - Preprocess
       - Fit model
       - Evaluate
       - Save model
@@ -151,12 +151,14 @@ def train(
     else:
         data = data_source
 
-    # Preprocess
-    X, y, preprocessor = preprocess_data(data, target_column)
+    # Split raw data before preprocessing
+    train_df, test_df = train_test_split(
+        data, test_size=test_size, random_state=random_state
+    )
 
-    # Split
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=test_size, random_state=random_state
+    # Preprocess using only the training data for fitting
+    X_train, y_train, X_test, y_test, preprocessor = preprocess_data(
+        train_df, target_column, test_df
     )
 
     # Train

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+from onelinerml.preprocessing import preprocess_data
+
+
+def test_preprocess_no_data_leakage():
+    train_df = pd.DataFrame({
+        'num': [1, 2, 3],
+        'cat': ['A', 'B', 'B'],
+        'target': [0, 1, 0]
+    })
+
+    test_df = pd.DataFrame({
+        'num': [4],
+        'cat': ['C'],
+        'target': [1]
+    })
+
+    X_train, y_train, X_test, y_test, preprocessor = preprocess_data(
+        train_df, 'target', test_df
+    )
+
+    cats = preprocessor.named_transformers_['cat']['onehot'].categories_[0].tolist()
+    assert cats == ['A', 'B']
+
+    # Category 'C' should be unseen and encoded as all zeros
+    cat_features = X_test[:, -len(cats):]
+    assert np.all(cat_features == 0)


### PR DESCRIPTION
## Summary
- split dataset before preprocessing in `train`
- fit preprocessing pipeline on train data only
- update preprocessing helper for train/test splits
- add regression test for preprocessing leakage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850153def60832ab807731184ede280