### PR TITLE
Add train_and_deploy helper, lazy-load optional models, and fix evaluation/dashboard behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You're a developer—your time is valuable. You don’t want to spend hours fine
 
 
 🚀 Get Started in Seconds
-from OneLinerML import train
+from onelinerml import train
 # Train a model in one line
 model, report = train("data.csv", target="price", algorithm="random_forest")
 print(report)
@@ -29,7 +29,16 @@ pip install OneLinerML
 
 ## Deployment
 
-Run locally with localtunnel:
+Run locally with localtunnel in one line:
+
+```python
+from onelinerml import train_and_deploy
+
+result = train_and_deploy("data.csv", target="price", algorithm="random_forest")
+print(result["api_url"], result["dashboard_url"])
+```
+
+CLI example:
 
 ```bash
 onelinerml-serve data.csv --target price --model random_forest --deploy-mode local
@@ -78,4 +87,3 @@ pip install OneLinerML
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-

--- a/onelinerml/__init__.py
+++ b/onelinerml/__init__.py
@@ -1,3 +1,3 @@
 # onelinerml/__init__.py
-from onelinerml.train import train
+from onelinerml.train import train, train_and_deploy
 from onelinerml.api import app as api_app

--- a/onelinerml/dashboard.py
+++ b/onelinerml/dashboard.py
@@ -15,7 +15,8 @@ if data_file is not None and st.button("Train Model"):
         data,
         model=model_choice,
         target_column=target_column,
-        preprocessor_save_path="preprocessor.joblib"
+        preprocessor_save_path="preprocessor.joblib",
+        deploy=False
     )
     st.write("Evaluation Metrics:")
     st.json(metrics)

--- a/onelinerml/evaluation.py
+++ b/onelinerml/evaluation.py
@@ -1,18 +1,23 @@
 # onelinerml/evaluation.py
-from sklearn.metrics import mean_squared_error, r2_score, accuracy_score, precision_score, recall_score, f1_score
-import numpy as np
+from sklearn.base import is_classifier
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    mean_squared_error,
+    precision_score,
+    r2_score,
+    recall_score,
+)
 
 def evaluate_model(model, X_test, y_test):
     y_pred = model.predict(X_test)
-    # Use regression metrics if target is numeric
-    if np.issubdtype(y_test.dtype, np.number):
-        mse = mean_squared_error(y_test, y_pred)
-        r2 = r2_score(y_test, y_pred)
-        return {"mean_squared_error": mse, "r2_score": r2}
-    else:
+    if is_classifier(model):
         # For classification tasks, compute additional metrics
         accuracy = accuracy_score(y_test, y_pred)
         precision = precision_score(y_test, y_pred, average="weighted", zero_division=0)
         recall = recall_score(y_test, y_pred, average="weighted", zero_division=0)
         f1 = f1_score(y_test, y_pred, average="weighted", zero_division=0)
         return {"accuracy": accuracy, "precision": precision, "recall": recall, "f1_score": f1}
+    mse = mean_squared_error(y_test, y_pred)
+    r2 = r2_score(y_test, y_pred)
+    return {"mean_squared_error": mse, "r2_score": r2}

--- a/onelinerml/models.py
+++ b/onelinerml/models.py
@@ -1,11 +1,18 @@
-from sklearn.linear_model import LinearRegression, LogisticRegression
-from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier, IsolationForest
-from xgboost import XGBRegressor, XGBClassifier
-from lightgbm import LGBMRegressor, LGBMClassifier
+from importlib import import_module
 
-# AutoML imports
-from autosklearn.regression import AutoSklearnRegressor
-from autosklearn.classification import AutoSklearnClassifier
+from sklearn.ensemble import IsolationForest, RandomForestClassifier, RandomForestRegressor
+from sklearn.linear_model import LinearRegression, LogisticRegression
+
+
+def _import_optional(module_name, attr_name):
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            f"Optional dependency '{module_name}' is required for this model. "
+            f"Install it to use '{attr_name}'."
+        ) from exc
+    return getattr(module, attr_name)
 
 def get_model(model_name, **kwargs):
     """
@@ -34,18 +41,26 @@ def get_model(model_name, **kwargs):
     elif model_name == "isolation_forest":
         return IsolationForest(**kwargs)
     elif model_name == "xgboost_regressor":
-        return XGBRegressor(**kwargs)
+        return _import_optional("xgboost", "XGBRegressor")(**kwargs)
     elif model_name == "xgboost_classifier":
-        return XGBClassifier(**kwargs)
+        return _import_optional("xgboost", "XGBClassifier")(**kwargs)
     elif model_name == "lightgbm_regressor":
-        return LGBMRegressor(**kwargs)
+        return _import_optional("lightgbm", "LGBMRegressor")(**kwargs)
     elif model_name == "lightgbm_classifier":
-        return LGBMClassifier(**kwargs)
+        return _import_optional("lightgbm", "LGBMClassifier")(**kwargs)
     elif model_name == "auto_sklearn_regressor":
         # AutoML regressor with default 1-minute training time by default
-        return AutoSklearnRegressor(time_left_for_this_task=60, **kwargs)
+        autosklearn_regressor = _import_optional(
+            "autosklearn.regression",
+            "AutoSklearnRegressor",
+        )
+        return autosklearn_regressor(time_left_for_this_task=60, **kwargs)
     elif model_name == "auto_sklearn_classifier":
         # AutoML classifier with default 1-minute training time by default
-        return AutoSklearnClassifier(time_left_for_this_task=60, **kwargs)
+        autosklearn_classifier = _import_optional(
+            "autosklearn.classification",
+            "AutoSklearnClassifier",
+        )
+        return autosklearn_classifier(time_left_for_this_task=60, **kwargs)
     else:
         raise ValueError(f"Model '{model_name}' is not supported.")

--- a/onelinerml/train.py
+++ b/onelinerml/train.py
@@ -116,10 +116,58 @@ def deploy_model_from_path(
         return deploy_api_and_dashboard_cloud(config_path)
     return deploy_api_and_dashboard_localtunnel(api_port, dashboard_port)
 
+
+def train_and_deploy(
+    data_source,
+    model="linear_regression",
+    target_column="target",
+    target=None,
+    algorithm=None,
+    test_size=0.2,
+    random_state=42,
+    model_save_path="trained_model.joblib",
+    preprocessor_save_path="preprocessor.joblib",
+    api_port=8000,
+    dashboard_port=8503,
+    deploy_mode="local",
+    config_path=None,
+    **kwargs,
+):
+    """Train a model and immediately deploy the API + dashboard."""
+    model_instance, metrics = train(
+        data_source=data_source,
+        model=model,
+        target_column=target_column,
+        target=target,
+        algorithm=algorithm,
+        test_size=test_size,
+        random_state=random_state,
+        model_save_path=model_save_path,
+        preprocessor_save_path=preprocessor_save_path,
+        api_port=api_port,
+        dashboard_port=dashboard_port,
+        deploy_mode=deploy_mode,
+        config_path=config_path,
+        deploy=False,
+        **kwargs,
+    )
+    if deploy_mode == "cloud":
+        api_url, dash_url = deploy_api_and_dashboard_cloud(config_path)
+    else:
+        api_url, dash_url = deploy_api_and_dashboard_localtunnel(api_port, dashboard_port)
+    return {
+        "model": model_instance,
+        "metrics": metrics,
+        "api_url": api_url,
+        "dashboard_url": dash_url,
+    }
+
 def train(
     data_source,
     model="linear_regression",
     target_column="target",
+    target=None,
+    algorithm=None,
     test_size=0.2,
     random_state=42,
     model_save_path="trained_model.joblib",
@@ -145,11 +193,20 @@ def train(
     deploy : bool, optional
         If True, deploy the API and dashboard after training. Defaults to True.
     """
+    if target is not None:
+        target_column = target
+    if algorithm is not None:
+        model = algorithm
     # Load data
     if isinstance(data_source, str):
+        if not os.path.exists(data_source):
+            raise FileNotFoundError(f"Data file not found: {data_source}")
         data = pd.read_csv(data_source)
     else:
         data = data_source
+
+    if target_column not in data.columns:
+        raise ValueError(f"Target column '{target_column}' not found in data.")
 
     # Preprocess
     X, y, preprocessor = preprocess_data(data, target_column)
@@ -213,4 +270,3 @@ def main():
         deploy_mode=args.deploy_mode,
         config_path=args.config_path,
     )
-


### PR DESCRIPTION
### Motivation
- Provide a true one-line train+deploy helper so users can train and expose a model with minimal code.
- Avoid forcing heavy optional dependencies (XGBoost/LightGBM/AutoSklearn) to be installed unless used.
- Correct metric selection for classification vs regression and avoid accidental deployment from the dashboard UI.

### Description
- Add a lazy importer `_import_optional` and use it in `onelinerml/models.py` to raise clear errors only when optional models are requested instead of importing heavy packages at module import time.
- Update `onelinerml/evaluation.py` to use `sklearn.base.is_classifier` and compute classification metrics for classifiers and regression metrics otherwise.
- Add `train_and_deploy` helper in `onelinerml/train.py` and add `target`/`algorithm` aliases plus basic input validation and file existence checks to make the API simpler and more robust.
- Prevent the Streamlit dashboard from triggering deployment by passing `deploy=False` during dashboard-triggered training and export `train_and_deploy` from the package root; update `README.md` to show the new one-line usage example.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e8b96058832a924a1b2fb4545906)